### PR TITLE
Added forwarding of events to Honeycomb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,30 +1,32 @@
 [package]
 authors = ["Henrik Tougaard <henrik@adaptagency.com>"]
 name = "axum-otlp-honeycomb"
-version = "0.3.0"
+version = "0.3.3"
 edition = "2021"
 
 [dependencies]
+axum = "0.7"
+clap = { version = "4", features = ["cargo"] }
+futures-util = "0.3"
+http = "1"
+opentelemetry = { version = "0.27", features = [
+    "trace",
+], default-features = false }
+opentelemetry-appender-tracing = "0.27.0"
+opentelemetry-http = "0.27"
 opentelemetry-otlp = { version = "0.27", features = [
     "reqwest-client",
     "reqwest-rustls",
     "http-proto",
+    "logs",
 ], default-features = false }
-opentelemetry = { version = "0.27", features = [
-    "trace",
-], default-features = false }
-opentelemetry-http = "0.27"
 opentelemetry_sdk = { version = "0.27", features = [
     "trace",
     "rt-tokio",
 ], default-features = false }
-tracing-opentelemetry = "0.28"
-tracing-core = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 pin-project-lite = "0.2"
-http = "1"
 tower = "0.5"
 tracing = "0.1"
-futures-util = "0.3"
-axum = "0.7"
-clap = { version = "4", features = ["cargo"] }
+tracing-core = "0.1"
+tracing-opentelemetry = "0.28"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cargo add clap --features cargo
 
 Where you create your tracing_subscriber do this:
 ```
-use axum_otlp_honeycomb::init_otlp_layer;
+use axum_otlp_honeycomb::{init_otlp_layer, init_otlp_log_layer};
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::prelude::*;
@@ -56,10 +56,20 @@ tracing_subscriber::Registry::default()
             .with_filter(EnvFilter::from_default_env()),
     )
     .with(init_otlp_layer(sample_rate).with_filter(LevelFilter::INFO))
+    .with(init_otlp_log_layer().with_filter(LevelFilter::INFO))
     .init();
 ```
 The first `.with` is for local logging to eg Platform.sh's `app.log`. The log-level
 is set by the `RUST_LOG` environment variable.
+
+The second `.with` is for tracing to Honeycomb. `LevelFilter::INFO` ensures that tracing
+done with `#[tracing::instrument]` is forwarded. Logging with `LevelFilter::DEBUG` gives
+traces for just too much.
+
+The third `.with` is for forwarding events to Honeycomb's Logs. Again the `LevelFilter::WARN`
+ensures that only relevant events are forwarded.
+
+**NOTE**: Any event field named **`body`** will overwrite the event message.
 
 ### Add layers to Axum app
 

--- a/src/axum_layer.rs
+++ b/src/axum_layer.rs
@@ -131,7 +131,7 @@ fn headers<B>(req: &Request<B>) -> String {
         .headers()
         .iter()
         .filter(|(name, _)| {
-            *name != "authorization" && *name != "cookie" && name.as_str().contains("token")
+            *name != "authorization" && *name != "cookie" && !name.as_str().contains("token")
         })
         .map(|(n, v)| (n.clone(), v.clone()))
         .collect();

--- a/src/event_logger.rs
+++ b/src/event_logger.rs
@@ -1,0 +1,216 @@
+//! Logging of events
+
+use opentelemetry::{
+    logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
+    InstrumentationScope, Key,
+};
+use std::borrow::Cow;
+use tracing::Level;
+use tracing_subscriber::{registry::LookupSpan, Layer};
+const INSTRUMENTATION_LIBRARY_NAME: &str = "axum_otel_honeycomb";
+
+pub struct AxumOtelEventLogger<P, L>
+where
+    P: LoggerProvider<Logger = L> + Send + Sync,
+    L: Logger + Send + Sync,
+{
+    logger: L,
+    _phantom: std::marker::PhantomData<P>, // P is not used.
+}
+
+impl<P, L> AxumOtelEventLogger<P, L>
+where
+    P: LoggerProvider<Logger = L> + Send + Sync,
+    L: Logger + Send + Sync,
+{
+    pub fn new(provider: &P) -> Self {
+        let scope = InstrumentationScope::builder(INSTRUMENTATION_LIBRARY_NAME)
+            .with_version(Cow::Borrowed(env!("CARGO_PKG_VERSION")))
+            .build();
+
+        AxumOtelEventLogger {
+            logger: provider.logger_with_scope(scope),
+            _phantom: Default::default(),
+        }
+    }
+}
+
+/// All data and metadata from the span.
+#[derive(Debug)]
+struct ExtensionValues {
+    span_str: String,
+    location: String,
+}
+
+impl<S, P, L> Layer<S> for AxumOtelEventLogger<P, L>
+where
+    S: tracing::Subscriber + for<'lookup> LookupSpan<'lookup>,
+    P: LoggerProvider<Logger = L> + Send + Sync + 'static,
+    L: Logger + Send + Sync + 'static,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing_core::span::Attributes<'_>,
+        id: &tracing_core::span::Id,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if let Some(span) = ctx.span(id) {
+            let mut span_str = String::with_capacity(256);
+            let location = format!(
+                "{file}:{line}",
+                file = attrs.metadata().file().unwrap_or("UNKNOWN"),
+                line = attrs.metadata().line().unwrap_or_default(),
+            );
+            span_str.push_str(&format!(
+                "Name: '{name}', {{ module: '{module}', location: '{location}'",
+                name = attrs.metadata().name(),
+                module = attrs.metadata().module_path().unwrap_or_default(),
+                location = location,
+            ));
+
+            let mut visitor = SpanVisitor::new(&mut span_str);
+            attrs.values().record(&mut visitor);
+            span_str.push_str(" }");
+            let extension = ExtensionValues { span_str, location };
+            span.extensions_mut().insert(extension);
+        }
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let meta = event.metadata();
+
+        let mut log_record = self.logger.create_log_record();
+
+        // TODO: Fix heap allocation
+        log_record.set_target(meta.target().to_string());
+        log_record.set_event_name(meta.name());
+        log_record.set_severity_number(severity_of_level(meta.level()));
+        log_record.set_severity_text(meta.level().as_str());
+        log_record.add_attribute(
+            "location",
+            format!(
+                "{}:{}",
+                meta.file().unwrap_or("UNKNOWN"),
+                meta.line().unwrap_or_default()
+            ),
+        );
+        let mut visitor = EventVisitor::new(&mut log_record);
+        // Visit fields.
+        event.record(&mut visitor);
+        // Log spans.
+        if let Some(scope) = ctx.event_scope(event) {
+            for (i, span) in scope.from_root().enumerate() {
+                let ext = span.extensions();
+                if let Some(span_data) = ext.get::<ExtensionValues>() {
+                    log_record.add_attribute(format!("span.{i}"), span_data.span_str.clone());
+                    log_record
+                        .add_attribute(format!("span.{i}.location"), span_data.location.clone());
+                }
+                log_record.add_attribute(format!("span.{i}.name"), span.name());
+            }
+        }
+        //emit record
+        self.logger.emit(log_record);
+    }
+}
+
+const fn severity_of_level(level: &Level) -> Severity {
+    match *level {
+        Level::TRACE => Severity::Trace,
+        Level::DEBUG => Severity::Debug,
+        Level::INFO => Severity::Info,
+        Level::WARN => Severity::Warn,
+        Level::ERROR => Severity::Error,
+    }
+}
+
+/// Visitor to record the fields from the event record.
+struct EventVisitor<'a, LR: LogRecord> {
+    log_record: &'a mut LR,
+}
+
+impl<'a, LR: LogRecord> EventVisitor<'a, LR> {
+    fn new(log_record: &'a mut LR) -> Self {
+        EventVisitor { log_record }
+    }
+}
+
+impl<'a, LR: LogRecord> tracing::field::Visit for EventVisitor<'a, LR> {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.log_record.set_body(format!("{:?}", value).into());
+        } else {
+            self.log_record
+                .add_attribute(Key::new(field.name()), AnyValue::from(format!("{value:?}")));
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing_core::Field, value: &str) {
+        //TODO: Consider special casing "message" to populate body and document
+        // to users to use message field for log message, to avoid going to the
+        // record_debug, which has dyn dispatch, string allocation and
+        // formatting cost.
+
+        //TODO: Fix heap allocation. Check if lifetime of &str can be used
+        // to optimize sync exporter scenario.
+        self.log_record
+            .add_attribute(Key::new(field.name()), AnyValue::from(value.to_owned()));
+    }
+
+    fn record_bool(&mut self, field: &tracing_core::Field, value: bool) {
+        self.log_record
+            .add_attribute(Key::new(field.name()), AnyValue::from(value));
+    }
+
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        self.log_record
+            .add_attribute(Key::new(field.name()), AnyValue::from(value));
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.log_record
+            .add_attribute(Key::new(field.name()), AnyValue::from(value));
+    }
+
+    // TODO: Remaining field types from AnyValue : Bytes, ListAny, Boolean
+}
+
+/// Visitor to record the fields from the event record.
+struct SpanVisitor<'a> {
+    extension_values: &'a mut String,
+}
+
+impl<'a> SpanVisitor<'a> {
+    fn new(extension_values: &'a mut String) -> Self {
+        SpanVisitor { extension_values }
+    }
+}
+
+impl tracing::field::Visit for SpanVisitor<'_> {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.extension_values
+            .push_str(&format!(", {}: '{:?}'", field.name(), value))
+    }
+
+    fn record_str(&mut self, field: &tracing_core::Field, value: &str) {
+        self.extension_values
+            .push_str(&format!(", {}: '{}'", field.name(), value))
+    }
+
+    fn record_bool(&mut self, field: &tracing_core::Field, value: bool) {
+        self.extension_values
+            .push_str(&format!(", {}: '{}'", field.name(), value))
+    }
+
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        self.extension_values
+            .push_str(&format!(", {}: '{}'", field.name(), value))
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.extension_values
+            .push_str(&format!(", {}: '{}'", field.name(), value))
+    }
+
+    // TODO: Remaining field types from AnyValue : Bytes, ListAny, Boolean
+}


### PR DESCRIPTION
Added event_logger module.

Span-attributes are added to the event-data, so
the call stack can be seen even if the spans are not forwarded.